### PR TITLE
(fix) version of postgres is correct

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.2'
 ### mongodb Container #######################################
 services:
     postgres-oms-statutory:
-        image: postgres:10.6
+        image: postgres:11.1
         volumes:
             - postgres:/var/lib/postgresql/data
         expose:


### PR DESCRIPTION
Big mistake in assuming the version of postgres was same as oms-core