### PR TITLE
Mail board on application

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -15,7 +15,7 @@ const config = {
             port: 4000,
             user: {
                 login: process.env.CORE_LOGIN || 'admin@aegee.org',
-                password: process.env.CORE_PASSWORD || 'admin1234'
+                password: process.env.CORE_PASSWORD || '5ecr3t'
             }
         },
         mailer: {

--- a/config/index.js
+++ b/config/index.js
@@ -12,7 +12,11 @@ const config = {
         },
         core: {
             url: 'http://oms-core-elixir',
-            port: 4000
+            port: 4000,
+            user: {
+                login: process.env.CORE_LOGIN || 'admin@aegee.org',
+                password: process.env.CORE_PASSWORD || 'admin1234'
+            }
         },
         mailer: {
             url: 'http://oms-mailer',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,8 @@ services:
             PG_PASSWORD: "${PW_POSTGRES}"
             NODE_ENV: "${MYAEGEE_ENV}"
             HOST: "${SUBDOMAIN_FRONTEND}${BASE_URL}"
+            CORE_LOGIN: "${CORE_LOGIN}"
+            CORE_PASSWORD: "${CORE_PASSWORD}"
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8084/healthcheck"]
             interval: 30s

--- a/lib/applications.js
+++ b/lib/applications.js
@@ -275,7 +275,6 @@ exports.updateApplication = async (req, res) => {
 
         // Sending the mail to a user.
         await mailer.sendMail({
-            from: 'oms-mailer@aegee.org',
             to: req.application.email,
             subject: `Your application for ${req.event.name} was updated`,
             template: 'statutory_edited.html',
@@ -596,10 +595,25 @@ exports.postApplication = async (req, res) => {
 
         // Sending the mail to a user.
         await mailer.sendMail({
-            from: 'oms-mailer@aegee.org',
             to: newApplication.email,
             subject: `You've successfully applied for ${req.event.name}`,
             template: 'statutory_applied.html',
+            parameters: {
+                application: newApplication,
+                event: req.event
+            }
+        });
+
+        // Sending emails to board members of this body.
+        const boardMembers = await core.getBodyUsersForPermission({
+            action: 'approve_members',
+            object: req.event.type
+        }, newApplication.body_id);
+
+        await mailer.sendMail({
+            to: boardMembers.map(member => member.member.user.email),
+            subject: `One of your body members has applied to ${req.event.name}`,
+            template: 'statutory_board_applied.html',
             parameters: {
                 application: newApplication,
                 event: req.event

--- a/lib/core.js
+++ b/lib/core.js
@@ -19,6 +19,10 @@ const makeRequest = (options) => {
         requestOptions.body = options.body;
     }
 
+    if (options.qs) {
+        requestOptions.qs = options.qs;
+    }
+
     return request(requestOptions);
 };
 
@@ -96,11 +100,35 @@ const getMyPermissions = async (req) => {
     return permissionsBody;
 };
 
+const getBodyUsersForPermission = async (permission, bodyId) => {
+    // Getting access and refresh token.
+    const authRequest = await makeRequest({
+        url: config.core.url + ':' + config.core.port + '/login',
+        method: 'POST',
+        body: {
+            username: config.core.user.login,
+            password: config.core.user.password
+        }
+    });
+
+    // Fetching members.
+    const response = await makeRequest({
+        url: config.core.url + ':' + config.core.port + '/bodies/' + bodyId + '/members',
+        token: authRequest.access_token,
+        qs: {
+            holds_permission: { action: permission.action, object: permission.object }
+        }
+    });
+
+    return response.data;
+};
+
 module.exports = {
     getMember,
     getBody,
     getApprovePermissions,
     getBodies,
     getMyProfile,
-    getMyPermissions
+    getMyPermissions,
+    getBodyUsersForPermission
 };

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,31 +2,39 @@ const request = require('request-promise-native');
 
 const config = require('../config');
 
-module.exports.getMember = async (req, id) => {
-    const user = await request({
-        url: config.core.url + ':' + config.core.port + '/members/' + id,
-        method: 'GET',
+const makeRequest = (options) => {
+    const requestOptions = {
+        url: options.url,
+        method: options.method || 'GET',
         headers: {
             'X-Requested-With': 'XMLHttpRequest',
-            'X-Auth-Token': req.headers['x-auth-token'],
+            'X-Auth-Token': options.token,
         },
         simple: false,
-        json: true
+        json: true,
+        resolveWithFullResponse: options.resolveWithFullResponse || false
+    };
+
+    if (options.body) {
+        requestOptions.body = options.body;
+    }
+
+    return request(requestOptions);
+};
+
+const getMember = async (req, id) => {
+    const user = await makeRequest({
+        url: config.core.url + ':' + config.core.port + '/members/' + id,
+        token: req.headers['x-auth-token']
     });
 
     return user.data;
 };
 
-module.exports.getBody = async (req, id) => {
-    const body = await request({
+const getBody = async (req, id) => {
+    const body = await makeRequest({
         url: config.core.url + ':' + config.core.port + '/bodies/' + id,
-        method: 'GET',
-        headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-Auth-Token': req.headers['x-auth-token'],
-        },
-        simple: false,
-        json: true
+        token: req.headers['x-auth-token']
     });
 
     if (typeof body !== 'object') {
@@ -40,18 +48,13 @@ module.exports.getBody = async (req, id) => {
     return body.data;
 };
 
-module.exports.getApprovePermissions = async (req, event) => {
+const getApprovePermissions = async (req, event) => {
     // Fetching permissions for members approval, the list of bodies
     // where do you have the 'approve_members:<event_type>' permission for it.
-    const approveRequest = await request({
+    const approveRequest = await makeRequest({
         url: config.core.url + ':' + config.core.port + '/my_permissions',
         method: 'POST',
-        headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-Auth-Token': req.headers['x-auth-token'],
-        },
-        simple: false,
-        json: true,
+        token: req.headers['x-auth-token'],
         resolveWithFullResponse: true,
         body: {
             action: 'approve_members',
@@ -62,49 +65,42 @@ module.exports.getApprovePermissions = async (req, event) => {
     return approveRequest;
 };
 
-module.exports.getBodies = async (req) => {
-    const bodies = await request({
+const getBodies = async (req) => {
+    const bodies = await makeRequest({
         url: config.core.url + ':' + config.core.port + '/bodies',
-        method: 'GET',
-        headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-Auth-Token': req.headers['x-auth-token'],
-        },
-        simple: false,
-        json: true
+        token: req.headers['x-auth-token']
     });
 
     return bodies.data;
 };
 
-module.exports.getMyProfile = async (req) => {
-    const myProfileBody = await request({
+const getMyProfile = async (req) => {
+    const myProfileBody = await makeRequest({
         url: config.core.url + ':' + config.core.port + '/members/me',
         method: 'GET',
-        headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-Auth-Token': req.headers['x-auth-token'],
-        },
-        resolveWithFullResponse: true,
-        simple: false,
-        json: true,
+        token: req.headers['x-auth-token'],
+        resolveWithFullResponse: true
     });
 
     return myProfileBody;
 };
 
-module.exports.getMyPermissions = async (req) => {
-    const permissionsBody = await request({
+const getMyPermissions = async (req) => {
+    const permissionsBody = await makeRequest({
         url: config.core.url + ':' + config.core.port + '/my_permissions',
         method: 'GET',
-        headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-Auth-Token': req.headers['x-auth-token'],
-        },
-        resolveWithFullResponse: true,
-        simple: false,
-        json: true,
+        token: req.headers['x-auth-token'],
+        resolveWithFullResponse: true
     });
 
     return permissionsBody;
+};
+
+module.exports = {
+    getMember,
+    getBody,
+    getApprovePermissions,
+    getBodies,
+    getMyProfile,
+    getMyPermissions
 };

--- a/lib/massmailer.js
+++ b/lib/massmailer.js
@@ -67,7 +67,6 @@ exports.sendAll = async (req, res) => {
     logger.info('Prepared letters: ' + bodies.length);
 
     await mailer.sendMail({
-        from: req.body.from,
         reply_to: req.body.reply_to,
         to,
         subject: req.body.subject,

--- a/test/assets/oms-core-body-members.json
+++ b/test/assets/oms-core-body-members.json
@@ -1,0 +1,42 @@
+{
+    "success": true,
+    "data": [
+        {
+            "member_id": 4,
+            "member": {
+                "user_id": 9,
+                "user": {
+                    "superadmin": false,
+                    "name": "paul.smits",
+                    "member_id": 4,
+                    "inserted_at": "2018-05-04T11:16:50.531076",
+                    "id": 9,
+                    "email": "paul.l.smits@gmail.com",
+                    "active": true
+                },
+                "seo_url": "36125407_",
+                "primary_body_id": null,
+                "primary_body": null,
+                "phone": "+31649936487",
+                "last_name": "Smits",
+                "join_requests": null,
+                "id": 4,
+                "gender": "None",
+                "first_name": "Paul",
+                "date_of_birth": "1990-10-17",
+                "circles": null,
+                "circle_memberships": null,
+                "body_memberships": null,
+                "bodies": null,
+                "address": "Bunschoterplein 10, 6711CC Ede, Netherlands",
+                "about_me": "I am a not a microservice."
+            },
+            "inserted_at": "2018-05-04T21:04:15.243761",
+            "id": 1,
+            "has_expired": true,
+            "comment": null,
+            "body_id": 12,
+            "body": null
+        }
+    ]
+}


### PR DESCRIPTION
Fixes MEMB-311 and some others.

This is how it's working:
1. There's core login and pw now in config and it can (and should in production) be passed from the global `.env`
2. When somebody creates the application, this happens:

1) the `/login` core request is done, for fetching access token
2) the `/bodies/:id/members?holds_permissions[action]=approve_members&holds_permission[object]=<event type>` core request is done, to fetch the members of the body who can approve
3) a mail is sent to all of these users.

@linuxbandit asking for your review here because the `docker-compose.yml` file is touched here.